### PR TITLE
Add full stack demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,19 @@ This is the "G" in RAG. The powerful LLM (Google's Gemini Pro) receives this "au
 
 In short, **NotebookLM works by using a "search-then-synthesize" system (RAG) that forces a powerful language model to base its answers exclusively on your provided documents, complete with verifiable citations.**
 
+## Running the demo application
+
+This repository now contains a small full-stack demo built with FastAPI and a
+simple HTML/JS frontend. The backend exposes endpoints to ingest text files,
+query them and generate shareable notebook links.
+
+Install the requirements and run the development server:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Then open `http://localhost:8000` in your browser. The page lets you upload
+files, issue queries and request share links directly from the browser.
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,11 @@
 from enum import Enum
+from typing import List
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, UploadFile, File
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+from src.rag_pipeline import RAGPipeline
 
 
 class ShareMode(str, Enum):
@@ -10,6 +15,18 @@ class ShareMode(str, Enum):
 
 app = FastAPI()
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+pipeline = RAGPipeline()
+
+app.mount("/", StaticFiles(directory="frontend", html=True), name="static")
+
 
 @app.get("/share/{notebook_id}")
 def share_notebook(notebook_id: str, mode: ShareMode = Query(ShareMode.read_only)):
@@ -17,3 +34,24 @@ def share_notebook(notebook_id: str, mode: ShareMode = Query(ShareMode.read_only
     base_url = "https://example.com/notebooks"
     link = f"{base_url}/{notebook_id}?mode={mode.value}"
     return {"shareable_link": link}
+
+
+@app.post("/ingest")
+async def ingest(files: List[UploadFile] = File(...)):
+    """Ingest uploaded text files into the retrieval pipeline."""
+    paths = []
+    for f in files:
+        data = await f.read()
+        path = f"/tmp/{f.filename}"
+        with open(path, "wb") as out:
+            out.write(data)
+        paths.append(path)
+    pipeline.ingest_files(paths)
+    return {"status": "ingested", "count": len(paths)}
+
+
+@app.get("/query")
+def query(q: str):
+    """Return retrieved context for the query."""
+    prompt = pipeline.build_prompt(q)
+    return {"prompt": prompt}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,57 @@
     Your browser does not support the audio element.
 </audio>
 <p>Play offline: once loaded, this audio will be available without network.</p>
+
+<h2>Get Shareable Link</h2>
+<label>Notebook ID: <input id="nb-id" type="text"/></label>
+<label>Mode:
+  <select id="mode">
+    <option value="read-only">Read only</option>
+    <option value="interactive">Interactive</option>
+  </select>
+</label>
+<button id="share-btn">Share</button>
+<pre id="share-result"></pre>
+
+<h2>Ingest Files</h2>
+<input id="files" type="file" multiple/>
+<button id="ingest-btn">Ingest</button>
+<pre id="ingest-result"></pre>
+
+<h2>Query</h2>
+<input id="query" type="text" placeholder="Ask a question"/>
+<button id="query-btn">Send</button>
+<pre id="query-result"></pre>
 <script>
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('service-worker.js');
 }
+
+const $ = id => document.getElementById(id);
+
+$('#share-btn').onclick = async () => {
+    const id = $('#nb-id').value;
+    const mode = $('#mode').value;
+    const resp = await fetch(`/share/${id}?mode=${mode}`);
+    const data = await resp.json();
+    $('#share-result').textContent = data.shareable_link;
+};
+
+$('#ingest-btn').onclick = async () => {
+    const files = $('#files').files;
+    const fd = new FormData();
+    for (const f of files) fd.append('files', f);
+    const resp = await fetch('/ingest', {method: 'POST', body: fd});
+    const data = await resp.json();
+    $('#ingest-result').textContent = JSON.stringify(data, null, 2);
+};
+
+$('#query-btn').onclick = async () => {
+    const q = $('#query').value;
+    const resp = await fetch(`/query?q=${encodeURIComponent(q)}`);
+    const data = await resp.json();
+    $('#query-result').textContent = data.prompt;
+};
 </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
-
+fastapi
+uvicorn
+sentence-transformers
+faiss-cpu
+numpy
+pydub
+pyttsx3


### PR DESCRIPTION
## Summary
- add FastAPI server with CORS, file ingestion, query and share link endpoints
- serve the frontend via FastAPI
- extend frontend to call backend APIs
- document running the demo
- specify Python dependencies

## Testing
- `pip install --dry-run -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a462a3e4c832a903775efc626c762